### PR TITLE
[dependency] Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,22 +13,22 @@
   "main": "dist/index.js",
   "dependencies": {
     "graphviz": "^0.0.9",
-    "ts-morph": "^5.0.0",
+    "ts-morph": "^6.0.2",
     "typescript": "^3.7.3",
     "yargs": "^15.0.2"
   },
   "devDependencies": {
     "@types/graphviz": "^0.0.30",
-    "@types/node": "^12.12.14",
+    "@types/node": "^12.12.20",
     "@types/yargs": "^13.0.3",
-    "@typescript-eslint/eslint-plugin": "^2.10.0",
-    "@typescript-eslint/parser": "^2.10.0",
+    "@typescript-eslint/eslint-plugin": "^2.12.0",
+    "@typescript-eslint/parser": "^2.12.0",
     "@yarnpkg/pnpify": "^2.0.0-rc.12",
     "eslint": "^6.7.2",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.7.0",
     "eslint-import-resolver-node": "^0.3.2",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "^2.19.1",
     "prettier": "1.19.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,18 +61,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ts-morph/common@npm:~0.1.0":
-  version: 0.1.1
-  resolution: "@ts-morph/common@npm:0.1.1"
+"@ts-morph/common@npm:~0.2.2":
+  version: 0.2.2
+  resolution: "@ts-morph/common@npm:0.2.2"
   dependencies:
     "@dsherret/to-absolute-glob": ^2.0.2
+    fast-glob: ^3.1.0
     fs-extra: ^8.1.0
-    glob-parent: ^5.1.0
-    globby: ^10.0.1
     is-negated-glob: ^1.0.0
     multimatch: ^4.0.0
     typescript: ~3.7.2
-  checksum: e234d9ec6950288fbf5697e1b9de7ec19d47ec84c54c62b53499ed7bb711821ea05472898e7a73dad2c8413cb90d2e457be520543336ce8d830d563cdf865d14
+  checksum: 23d8f208c75891a34924cf9b442e81173aab252f099e45b016ba856f49a24cc7d6fb175321c69a820abe1b18aab3ad48047015ea75cf7b5b4247e47867c397d7
   languageName: node
   linkType: hard
 
@@ -90,24 +89,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/events@npm:*":
-  version: 3.0.0
-  resolution: "@types/events@npm:3.0.0"
-  checksum: 1fe4d45b4a29064c761efb988a111e9f46f3507c08311ff888edb792780ef1bdc2d988f34d2e03563e7fd3592e18c21032c21fdd608948028f0faeb3584adf3f
-  languageName: node
-  linkType: hard
-
-"@types/glob@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "@types/glob@npm:7.1.1"
-  dependencies:
-    "@types/events": "*"
-    "@types/minimatch": "*"
-    "@types/node": "*"
-  checksum: 6b33e589a6d9ca47da1571ba153b41b055697af1a5849f6d13b527fbf4a05f82b3c5ddaae435bf6cb57b8e6db31ee45c05004f4f50c561a1f50bd87daf546e60
-  languageName: node
-  linkType: hard
-
 "@types/graphviz@npm:^0.0.30":
   version: 0.0.30
   resolution: "@types/graphviz@npm:0.0.30"
@@ -122,17 +103,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimatch@npm:*, @types/minimatch@npm:^3.0.3":
+"@types/minimatch@npm:^3.0.3":
   version: 3.0.3
   resolution: "@types/minimatch@npm:3.0.3"
   checksum: c0a07410b9723d53260b5c471a0036204115b0a7866380142e6882c5a2a3521a5e6c9152a756696946daa422d6986dad00c3b8f5c883e0cb11412199b0612b9b
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^12.12.14":
-  version: 12.12.14
-  resolution: "@types/node@npm:12.12.14"
-  checksum: 5a8f6ea8bc43b9c867b0d5e0752ce42cdde7c90307417149a7ffb58149ee647fc79db7cbc7093e257757e1bd82500b6bf63e1dd6cace54f6aed18f7774937402
+"@types/node@npm:^12.12.20":
+  version: 12.12.20
+  resolution: "@types/node@npm:12.12.20"
+  checksum: 40f0238eeadab32df6f2a7d22ba6276fc6750dd5378a2f9af6fa8eaf7f13556500b18cf04f62c276c69e0f8c1739278836f8933edd9a33d691e3d49e48f9120c
   languageName: node
   linkType: hard
 
@@ -152,11 +133,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:2.10.0"
+"@typescript-eslint/eslint-plugin@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:2.12.0"
   dependencies:
-    "@typescript-eslint/experimental-utils": 2.10.0
+    "@typescript-eslint/experimental-utils": 2.12.0
     eslint-utils: ^1.4.3
     functional-red-black-tree: ^1.0.1
     regexpp: ^3.0.0
@@ -168,41 +149,44 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: b69c738012348e679c3d5c9332ef2f50eac6628801311e9ffe706149f6cff6cfdf7b35c1b8d4e5cdfaf945f424c0602ad9a9adf6051ead522853f76d9ac33938
+  checksum: 20c2d1189e13cc19ac0f7261f306cfd4d8b5ec63ac2085d198965a3fa41e3263c5668b44a5f25f67356d755dd89f0a4f1a9c45e94936ea98db71cca14b0997c0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/experimental-utils@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@typescript-eslint/experimental-utils@npm:2.10.0"
+"@typescript-eslint/experimental-utils@npm:2.12.0":
+  version: 2.12.0
+  resolution: "@typescript-eslint/experimental-utils@npm:2.12.0"
   dependencies:
     "@types/json-schema": ^7.0.3
-    "@typescript-eslint/typescript-estree": 2.10.0
+    "@typescript-eslint/typescript-estree": 2.12.0
     eslint-scope: ^5.0.0
   peerDependencies:
     eslint: "*"
-  checksum: 021d3c73a3d1a2324acea8e62264a8fcba57f1e7b4e9e285fd5c7f74dccc49afa8310accc2affed987164184a1aadd32370f71470b3cbf29003b195e33e9613f
+  checksum: e29ee43db6d1cd08b85e327d8c2ac294bb2ed1c94e57d3bbf12fc53631a26e4a03a8b0c61e3200290d29dc17ed8c5dc1c6ca8f9b67f23e6a64aa27ccc3639c3f
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "@typescript-eslint/parser@npm:2.10.0"
+"@typescript-eslint/parser@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "@typescript-eslint/parser@npm:2.12.0"
   dependencies:
     "@types/eslint-visitor-keys": ^1.0.0
-    "@typescript-eslint/experimental-utils": 2.10.0
-    "@typescript-eslint/typescript-estree": 2.10.0
+    "@typescript-eslint/experimental-utils": 2.12.0
+    "@typescript-eslint/typescript-estree": 2.12.0
     eslint-visitor-keys: ^1.1.0
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0
     typescript: "*"
-  checksum: 590032877e2ab92c70dcb9d5adf03445fb7ef214e5bfc73391ecb7b53d7283c7a8e798cc81c539805c492d6c111f205a0aebd5537d6ba3d589acb55bb6f52ba2
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: fe2e0f1be86518736e494f62e77c7ae7c4df9a6c15122e7d112bca5d5ada35d52c00adf0ca6d7e836c73bd3e5e6004c1fdcfbfe16a0eab9420d0741e5e29d430
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@typescript-eslint/typescript-estree@npm:2.10.0"
+"@typescript-eslint/typescript-estree@npm:2.12.0":
+  version: 2.12.0
+  resolution: "@typescript-eslint/typescript-estree@npm:2.12.0"
   dependencies:
     debug: ^4.1.1
     eslint-visitor-keys: ^1.1.0
@@ -216,7 +200,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 9c11b1735563ab76540be901cc98ce0c7664d0f98b47ab01ccb1e308285ef24970e287c223ef0ad1bf5d3205285ee46a0416513dc30ff4667a59c94a4c3462a3
+  checksum: 89673dcaa9b4fad2031d9c395f554ad46eda5b5265b80b07feffd5bf528c9b86b8cb960a54f32b0f98df534b3fd551830669b588d571f1ba155503582d1f5934
   languageName: node
   linkType: hard
 
@@ -347,12 +331,12 @@ __metadata:
   linkType: hard
 
 "array-includes@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "array-includes@npm:3.0.3"
+  version: 3.1.0
+  resolution: "array-includes@npm:3.1.0"
   dependencies:
-    define-properties: ^1.1.2
-    es-abstract: ^1.7.0
-  checksum: 4733eeb738328a49210ac8676ad4db07d2a638d0710e056796c4f5f4a801fb7455d9e901472e5805c10e7d5d82d000e59924e45638a8fc74459de4d427b55e15
+    define-properties: ^1.1.3
+    es-abstract: ^1.17.0-next.0
+  checksum: 71eddc35f35fcdbcefd1e18e907e3094f6a60adae6e688a510f3741a2619ce308c135842b359b902cd35346ba318378537b1ad0869a0575f8b97cbe0e57bcae4
   languageName: node
   linkType: hard
 
@@ -360,6 +344,16 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 60994e65b1cad2548478f36195c6829e7e9f7c9a46f2cca32bbf98f048fc9d4fc045b735559442a7a7c573453aa5d4aff2ee3d07e87621078e0fa74513000ad5
+  languageName: node
+  linkType: hard
+
+"array.prototype.flat@npm:^1.2.1":
+  version: 1.2.3
+  resolution: "array.prototype.flat@npm:1.2.3"
+  dependencies:
+    define-properties: ^1.1.3
+    es-abstract: ^1.17.0-next.1
+  checksum: 1b315d614db33df7b85b37d783396aee0bddaaaa6ef294cbf011052f9249e21dd7de0e28419619fa097fa277f86dda24df3e14ecee54e6333fc91bb4b04fddc2
   languageName: node
   linkType: hard
 
@@ -462,7 +456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"code-block-writer@npm:^10.0.0":
+"code-block-writer@npm:^10.1.0":
   version: 10.1.0
   resolution: "code-block-writer@npm:10.1.0"
   checksum: 49745cc857dbfa6f438d1980501c8d5b2b2ad7839b3cda3961f820fcf4bd679864e4ff42741a0a3ec7169d9a5386e81ade49310d5af8616640acae831de048e6
@@ -502,14 +496,14 @@ __metadata:
   linkType: hard
 
 "comment-json@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "comment-json@npm:2.2.0"
+  version: 2.3.1
+  resolution: "comment-json@npm:2.3.1"
   dependencies:
     core-util-is: ^1.0.2
     esprima: ^4.0.1
     has-own-prop: ^2.0.0
     repeat-string: ^1.6.1
-  checksum: 4934f6efb43c18ec0adc6d0a9ed535a2ac1360c2f3b53c1af677c9e87ee9ef5841d3ebc85600aad760e4097e9762718a716a423a3db54019b6ccd547719bddd7
+  checksum: d563f007cb9b5a914182fa7356a88eef7cbc68ffe5711b6a5703e4c138c5441faa552d6cecb22e5ba87f53739db3b91d54b78e25a0e8bfebe29493a769c988c6
   languageName: node
   linkType: hard
 
@@ -554,7 +548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^2.6.8, debug@npm:^2.6.9":
+"debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -592,15 +586,6 @@ __metadata:
   dependencies:
     object-keys: ^1.0.12
   checksum: 8ea9a3d1d6f9b5ec39f3acdf52c1f406cee2e15630b374daef2b44e67296cbf383481abc30beefa6cccde585ee5c41aa6d80c5c4556e90ffce95bea76f51857e
-  languageName: node
-  linkType: hard
-
-"dir-glob@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "dir-glob@npm:3.0.1"
-  dependencies:
-    path-type: ^4.0.0
-  checksum: 39531b593f4df4289e3006b00b003ef37ff6297342bb81601d35ad07864134dcbf83fe170165ba9eb4dc078592e568ad202edd47a6b58c50771cea2d4d2faf22
   languageName: node
   linkType: hard
 
@@ -646,9 +631,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.12.0, es-abstract@npm:^1.7.0":
-  version: 1.16.3
-  resolution: "es-abstract@npm:1.16.3"
+"es-abstract@npm:^1.17.0-next.0, es-abstract@npm:^1.17.0-next.1":
+  version: 1.17.0-next.1
+  resolution: "es-abstract@npm:1.17.0-next.1"
   dependencies:
     es-to-primitive: ^1.2.1
     function-bind: ^1.1.1
@@ -658,9 +643,10 @@ __metadata:
     is-regex: ^1.0.4
     object-inspect: ^1.7.0
     object-keys: ^1.1.1
+    object.assign: ^4.1.0
     string.prototype.trimleft: ^2.1.0
     string.prototype.trimright: ^2.1.0
-  checksum: edaedcd4594e7824ed7f6d4154003017b59b835885ec7ad1b97eab1d156b2a23b10361e189c8f81b9d6a5deb271d53e0317b8c73f0391ccb554fde8b2ead4bb2
+  checksum: c6257f2b5d2633593ce7384ae5eb16677349c3e3cac1c439f28b4dd0a7d7ea17b275e237cb317a3c08dc220ff43579e6d89010f1e17a3eb9ab08062c53abc7fe
   languageName: node
   linkType: hard
 
@@ -719,34 +705,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.4.0":
-  version: 2.4.1
-  resolution: "eslint-module-utils@npm:2.4.1"
+"eslint-module-utils@npm:^2.4.1":
+  version: 2.5.0
+  resolution: "eslint-module-utils@npm:2.5.0"
   dependencies:
-    debug: ^2.6.8
+    debug: ^2.6.9
     pkg-dir: ^2.0.0
-  checksum: 5b089acf49236cae5650afe01ddedb18da182257c0c898bb8c0e71707a2f7c27c2d0df1e1d7da8bb257e063e5578fb6f2d21352061f71e949cf245cf19b47897
+  checksum: 6750a2a69fbec1c4572f885d5521e0db03899331d3554f1ce0558bd7eacab7640e940f293003a2a8143dd31632bb52bd0bdad8a50cf10f9db498b0522ab3b05d
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.18.2":
-  version: 2.18.2
-  resolution: "eslint-plugin-import@npm:2.18.2"
+"eslint-plugin-import@npm:^2.19.1":
+  version: 2.19.1
+  resolution: "eslint-plugin-import@npm:2.19.1"
   dependencies:
     array-includes: ^3.0.3
+    array.prototype.flat: ^1.2.1
     contains-path: ^0.1.0
     debug: ^2.6.9
     doctrine: 1.5.0
     eslint-import-resolver-node: ^0.3.2
-    eslint-module-utils: ^2.4.0
+    eslint-module-utils: ^2.4.1
     has: ^1.0.3
     minimatch: ^3.0.4
     object.values: ^1.1.0
     read-pkg-up: ^2.0.0
-    resolve: ^1.11.0
+    resolve: ^1.12.0
   peerDependencies:
     eslint: 2.x - 6.x
-  checksum: 2b74d056aa5b8f19979a991fa38e3c8836ea53bc01f50a0d7dd4f1be2bcafbad6e1e3b81cecd6e7faae9c91bda5d1fad77f0a7dfc06a8058c78c405d7d4008a5
+  checksum: debe105aa46d63fb336817e241c401867890c3954ff6e667ecfa986ac9974dbbdf6044d2c9f0921d92a4d81c7e8daaf048b922f8c6f6bb4acd1290be35fb4ab5
   languageName: node
   linkType: hard
 
@@ -894,7 +881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.0.3":
+"fast-glob@npm:^3.1.0":
   version: 3.1.1
   resolution: "fast-glob@npm:3.1.1"
   dependencies:
@@ -908,9 +895,9 @@ __metadata:
   linkType: hard
 
 "fast-json-stable-stringify@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "fast-json-stable-stringify@npm:2.0.0"
-  checksum: cd22848b7072f690a6d37af85ecafcb55d7324386e8383e8a4c4a68a6f63c551a791616d8f63caddeb287a07ed855067120ef894df9f7ce8e1d32ee2a00016c9
+  version: 2.1.0
+  resolution: "fast-json-stable-stringify@npm:2.1.0"
+  checksum: b283f2a6f85792d6a1a25f17b0d8d5c460d579cd2df6dbfe71661936dbc08eb29ae074f1bdd642d58196dfb3027bf12bb9dbac9f511b4d43bacae5bd5a90aef1
   languageName: node
   linkType: hard
 
@@ -1072,22 +1059,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "globby@npm:10.0.1"
-  dependencies:
-    "@types/glob": ^7.1.1
-    array-union: ^2.1.0
-    dir-glob: ^3.0.1
-    fast-glob: ^3.0.3
-    glob: ^7.1.3
-    ignore: ^5.1.1
-    merge2: ^1.2.3
-    slash: ^3.0.0
-  checksum: 7c113286389ff8df12be6e1806837d37ab0f2d020528e7042ba7dac3b2d31ab6054b3a642566028a5d386d3553f6ed5681ddc5d2b339fbba3c4b4c846fa288cc
-  languageName: node
-  linkType: hard
-
 "graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0":
   version: 4.2.3
   resolution: "graceful-fs@npm:4.2.3"
@@ -1125,7 +1096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has@npm:^1.0.1, has@npm:^1.0.3":
+"has@npm:^1.0.3":
   version: 1.0.3
   resolution: "has@npm:1.0.3"
   dependencies:
@@ -1154,13 +1125,6 @@ __metadata:
   version: 4.0.6
   resolution: "ignore@npm:4.0.6"
   checksum: 17e717b3e9678a915f6a90c5c52358010ab3c1f8f71bd00e41f4a04c639d55d0b942435430ad7177f35ecfcc93c0ebf7c43933b28b2a5203a446e065a81abd54
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^5.1.1":
-  version: 5.1.4
-  resolution: "ignore@npm:5.1.4"
-  checksum: fede475966a10c234369ac949144d7256b38ad197c54b13e8bc1ba6235f6522999af65bc271896e141c6321089389262cdf518f9cdfe3dfc3b2f2c800879660c
   languageName: node
   linkType: hard
 
@@ -1199,8 +1163,8 @@ __metadata:
   linkType: hard
 
 "inquirer@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "inquirer@npm:7.0.0"
+  version: 7.0.1
+  resolution: "inquirer@npm:7.0.1"
   dependencies:
     ansi-escapes: ^4.2.1
     chalk: ^2.4.2
@@ -1211,11 +1175,11 @@ __metadata:
     lodash: ^4.17.15
     mute-stream: 0.0.8
     run-async: ^2.2.0
-    rxjs: ^6.4.0
+    rxjs: ^6.5.3
     string-width: ^4.1.0
     strip-ansi: ^5.1.0
     through: ^2.3.6
-  checksum: 0e1a60946f59957b9cda530666ec1a77e291d298e3616510a7455ad133037d7ebd57fe76d656d7df8f75d0fd3a9ad26d3ed35f9ca14074508ada7dd2dd346139
+  checksum: 35951fbed8d28cee9abaf0f22bd3a6c22291854d29ace5025aaa8521afb5a155b4bfab373e9b4c19ae4cfa796076ba99d88e60c642c3ee5ba70e591a5131ac7e
   languageName: node
   linkType: hard
 
@@ -1302,11 +1266,11 @@ __metadata:
   linkType: hard
 
 "is-regex@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "is-regex@npm:1.0.4"
+  version: 1.0.5
+  resolution: "is-regex@npm:1.0.5"
   dependencies:
-    has: ^1.0.1
-  checksum: 64dc136eb4bcdb7e564d34f9ad6f5674adf434a8063b4f24ddd871576cddc8efddf87949389af8294038a4e154832c3ba34f0cb9d30c4bfb00398f9b4888c0ed
+    has: ^1.0.3
+  checksum: 35a87c521c846fde740ec7c1910b75ad1f1e13db4381cc18373c556f909efba44e23a3cb70b760002eeecc7fc060e37fbf659598852807f82531fdc28a065cd9
   languageName: node
   linkType: hard
 
@@ -1458,7 +1422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.2.3, merge2@npm:^1.3.0":
+"merge2@npm:^1.3.0":
   version: 1.3.0
   resolution: "merge2@npm:1.3.0"
   checksum: dbcb0fa83b00cab318e82b8c370d13291a7583d2432521959246fc8048549a3d9c4fec3a7f52d17a2c071499b56dcaacceb9f543c08475235cf99d6b9ff9109f
@@ -1596,26 +1560,26 @@ __metadata:
   linkType: hard
 
 "object.entries@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "object.entries@npm:1.1.0"
+  version: 1.1.1
+  resolution: "object.entries@npm:1.1.1"
   dependencies:
     define-properties: ^1.1.3
-    es-abstract: ^1.12.0
+    es-abstract: ^1.17.0-next.1
     function-bind: ^1.1.1
     has: ^1.0.3
-  checksum: 806cc7902246594d5830906c39377f92e2357b671ee40c679a01171f351d831f9148251c54d9a93810babe7252eec41023b1937c3a0e6d13d2ebc6701399d784
+  checksum: f4619cc514502b7cbb70645ed21b858d05b8fea10e812d27840a3e5dab80a24a028dc0c6f33e5ffe8cab9bdea70eafe244fbd814d458bce9e0ad94b9225ee1b7
   languageName: node
   linkType: hard
 
 "object.values@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "object.values@npm:1.1.0"
+  version: 1.1.1
+  resolution: "object.values@npm:1.1.1"
   dependencies:
     define-properties: ^1.1.3
-    es-abstract: ^1.12.0
+    es-abstract: ^1.17.0-next.1
     function-bind: ^1.1.1
     has: ^1.0.3
-  checksum: fd3cc96a643a66baf08b798f9b23450554d8e663063423090cd9e53c585af2934049b72fb71676af76b6766120ba9686417c70f3eaee64954279ee0cfc9c4509
+  checksum: 5dbd6ce3ef9e86ba4078db565c679b0eacf969b477f9222455aadf41c7c2adfa0a98512873d06a8ed73056a04579773d46e594dbc590d9bd78140069454b1e7b
   languageName: node
   linkType: hard
 
@@ -1770,13 +1734,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-type@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "path-type@npm:4.0.0"
-  checksum: 2b11a18b110715261f17bb450bf8e87d2a45bb41762b52658c1301fe89524be49b1bde75635ddfbfe7289d90ea59f46acfbdd2776d55f195ce393af59c0668b5
-  languageName: node
-  linkType: hard
-
 "picomatch@npm:^2.0.5":
   version: 2.1.1
   resolution: "picomatch@npm:2.1.1"
@@ -1893,12 +1850,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.11.0, resolve@npm:^1.5.0":
-  version: 1.13.1
-  resolution: "resolve@npm:1.13.1"
+"resolve@npm:^1.10.0, resolve@npm:^1.12.0, resolve@npm:^1.5.0":
+  version: 1.14.0
+  resolution: "resolve@npm:1.14.0"
   dependencies:
     path-parse: ^1.0.6
-  checksum: 3403913540dd0d5f4908513878576ff7bcee81b1b48f6d323ffad5090236100ef50d98ea268273746c98742249bad76cae3b38e15d88fd0c0a95c96d28e49052
+  checksum: 529302f862803d44502ac61008e0b43417174fa206566fc934caab14b99705afb5387cdd0c8d2aef7c564c42b8b2d4c69f15372035e983714f97d505d42a8f6e
   languageName: node
   linkType: hard
 
@@ -1957,7 +1914,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^6.4.0":
+"rxjs@npm:^6.5.3":
   version: 6.5.3
   resolution: "rxjs@npm:6.5.3"
   dependencies:
@@ -2018,13 +1975,6 @@ __metadata:
   version: 3.0.2
   resolution: "signal-exit@npm:3.0.2"
   checksum: b3d9a5567188a680bdb67fb996c2ffe49dfb1db5295d4e55e34ce77ca8e7a9f3f81672b71279fed5dcb2057afd133a5a7d5bd4de4652a8714c668460900f183c
-  languageName: node
-  linkType: hard
-
-"slash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "slash@npm:3.0.0"
-  checksum: ce51757f17a5527c418ba0357ec96806a587383b48120abec4983aea914f7eed82693ea4dcf7d740bf9edc8b2d45ea46c32af2bf18ef0d7f56bc772febab6ba6
   languageName: node
   linkType: hard
 
@@ -2223,14 +2173,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-morph@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "ts-morph@npm:5.0.0"
+"ts-morph@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "ts-morph@npm:6.0.2"
   dependencies:
     "@dsherret/to-absolute-glob": ^2.0.2
-    "@ts-morph/common": ~0.1.0
-    code-block-writer: ^10.0.0
-  checksum: cab8f41faa599038a92484a15539c0235e930cce64a6a776bed5f3f95fb5c287a409896e73f30f077f4a2d19e1542db7bcef988a69192b92877c806bc6b2d7f2
+    "@ts-morph/common": ~0.2.2
+    code-block-writer: ^10.1.0
+  checksum: 60d180dfd44f2667d5dc84f9e48a5a6f74d4e8eb05ff8366f067376c0086d6b3b3e8d44ad74fa85f4877c80b1be838a33a2d3b03ec443cff86a89369f771f114
   languageName: node
   linkType: hard
 
@@ -2246,19 +2196,19 @@ __metadata:
   resolution: "tssa@workspace:."
   dependencies:
     "@types/graphviz": ^0.0.30
-    "@types/node": ^12.12.14
+    "@types/node": ^12.12.20
     "@types/yargs": ^13.0.3
-    "@typescript-eslint/eslint-plugin": ^2.10.0
-    "@typescript-eslint/parser": ^2.10.0
+    "@typescript-eslint/eslint-plugin": ^2.12.0
+    "@typescript-eslint/parser": ^2.12.0
     "@yarnpkg/pnpify": ^2.0.0-rc.12
     eslint: ^6.7.2
     eslint-config-airbnb-base: ^14.0.0
     eslint-config-prettier: ^6.7.0
     eslint-import-resolver-node: ^0.3.2
-    eslint-plugin-import: ^2.18.2
+    eslint-plugin-import: ^2.19.1
     graphviz: ^0.0.9
     prettier: 1.19.1
-    ts-morph: ^5.0.0
+    ts-morph: ^6.0.2
     typescript: ^3.7.3
     yargs: ^15.0.2
   languageName: unknown


### PR DESCRIPTION
This is a significant bump.
I no longer need to manually edit yarn.lock to workaround typescript-eslint optional peer dependencies issues.