### PR TITLE
[cli] Do not hide css dependency analysis results in details

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,12 +125,9 @@ ${dependencyListToString(allTSReverseDependencyChain)}
   const cssAnalysisResultString =
     allCssDependencyChain.length === 0
       ? null
-      : `<details>
-  <summary>Modules that your changes in css code may affect:</summary>
+      : `Modules that your changes in css code may affect:
 
-${dependencyListToString(allCssDependencyChain)}
-
-</details>`;
+${dependencyListToString(allCssDependencyChain)}`;
 
   const analysisResultString = [
     tsDirectReverseDependencyAnalysisResultString,


### PR DESCRIPTION
They are important signals that usually should not be ignored.