### PR TITLE
[top-level] Split api.ts into main-analyzer and tssa-result formatter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,25 +2,24 @@
 
 import { readFileSync } from 'fs';
 
-import getTSSAResultString from './api';
 import { getPullRequestDiff, commentOnPullRequest } from './github-operations';
+import getTSSAResult from './main-analyzer';
+import { tssaResultToString } from './tssa-result';
 
 const main = async () => {
-  if (process.env.CI && process.env.GITHUB_TOKEN) {
-    const analysisResultString = getTSSAResultString(
+  const onCI = Boolean(process.env.CI);
+  const analysisResultString = tssaResultToString(
+    getTSSAResult(
       process.argv.slice(2),
-      await getPullRequestDiff()
-    );
-    // eslint-disable-next-line no-console
-    console.log(analysisResultString);
+      onCI ? await getPullRequestDiff() : readFileSync(process.stdin.fd).toString()
+    )
+  );
+
+  // eslint-disable-next-line no-console
+  console.log(analysisResultString);
+
+  if (onCI) {
     commentOnPullRequest('[tssa]\n\n', analysisResultString);
-  } else {
-    const analysisResultString = getTSSAResultString(
-      process.argv.slice(2),
-      readFileSync(process.stdin.fd).toString()
-    );
-    // eslint-disable-next-line no-console
-    console.log(analysisResultString);
   }
 };
 

--- a/src/tssa-result.ts
+++ b/src/tssa-result.ts
@@ -1,0 +1,45 @@
+import type { SourceFileDefinedSymbol } from './typescript-projects';
+
+export type TssaResult = {
+  readonly typescriptAnalysisResult: readonly {
+    readonly changedFilePath: string;
+    readonly affectedFunctionChain: readonly SourceFileDefinedSymbol[];
+  }[];
+  /** A list of css affect chain. TODO: separate the result per file. */
+  readonly cssAnalysisResult: readonly string[];
+};
+
+const dependencyListToString = (list: readonly string[]): string =>
+  list.map((it) => `> \`${it}\``).join('\n');
+
+const sourceFileDefinedSymbolToString = (symbol: SourceFileDefinedSymbol): string =>
+  `${symbol.sourceFilePath} > ${symbol.name}`;
+
+export const tssaResultToString = ({
+  typescriptAnalysisResult,
+  cssAnalysisResult,
+}: TssaResult): string => {
+  const tsDependencyAnalysisResultStrings = typescriptAnalysisResult.map(
+    ({ changedFilePath, affectedFunctionChain }) => {
+      if (affectedFunctionChain.length === 0) return null;
+      return `Your changes in ${changedFilePath} may directly or indirectly affect:
+
+${dependencyListToString(affectedFunctionChain.map(sourceFileDefinedSymbolToString))}`;
+    }
+  );
+
+  const cssAnalysisResultString =
+    cssAnalysisResult.length === 0
+      ? null
+      : `Modules that your changes in css code may affect:
+
+${dependencyListToString(cssAnalysisResult)}`;
+
+  const analysisResultStrings = [
+    ...tsDependencyAnalysisResultStrings,
+    cssAnalysisResultString,
+  ].filter((it): it is string => it != null);
+  return analysisResultStrings.length === 0
+    ? 'No notable changes.'
+    : analysisResultStrings.join('\n\n');
+};


### PR DESCRIPTION
Let's make main-analyzer only do the computation and let something else to take care of the formatting.