### PR TITLE
[misc] Apply fixes to make tssa work for yarn v2 monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-sam/tssa",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "license": "AGPLv3",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,23 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'fs';
-
 import { getPullRequestDiff, commentOnPullRequest } from './github-operations';
 import getTSSAResult from './main-analyzer';
 import { tssaResultToString } from './tssa-result';
 
+const getStandardIn = async (): Promise<string> =>
+  new Promise((resolve) => {
+    let content = '';
+    process.stdin.resume();
+    process.stdin.on('data', (buffer) => {
+      content += buffer.toString();
+    });
+    process.stdin.on('end', () => resolve(content));
+  });
+
 const main = async () => {
   const onCI = Boolean(process.env.CI);
   const analysisResultString = tssaResultToString(
-    getTSSAResult(
-      process.argv.slice(2),
-      onCI ? await getPullRequestDiff() : readFileSync(process.stdin.fd).toString()
-    )
+    getTSSAResult(process.argv.slice(2), onCI ? await getPullRequestDiff() : await getStandardIn())
   );
 
   // eslint-disable-next-line no-console

--- a/src/typescript-projects.ts
+++ b/src/typescript-projects.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 import { dirname, join, relative, resolve } from 'path';
 
 import {
@@ -44,9 +44,9 @@ export default class TypeScriptProjects {
     const sourceFileMapping = new Map<string, SourceFile>();
 
     this.projectDirectories.forEach((projectDirectory) => {
-      const project = new Project({
-        tsConfigFilePath: join(projectDirectory, 'tsconfig.json'),
-      });
+      const tsConfigFilePath = join(projectDirectory, 'tsconfig.json');
+      if (!existsSync(tsConfigFilePath)) return;
+      const project = new Project({ tsConfigFilePath });
       projectMappings.set(projectDirectory, project);
 
       const projectSourceFilesList = project.getSourceFiles().map((sourceFile) => {


### PR DESCRIPTION
- Do not use fs.readSync to read stdin to avoid conflicting with yarn v2's patch on fs.
- Allow missing typescript project config.