### PR TITLE
Split TSSA results by file

### DIFF
--- a/src/__test__/dependency-graph-analyzer.test.ts
+++ b/src/__test__/dependency-graph-analyzer.test.ts
@@ -17,7 +17,7 @@ it('getTopologicallyOrderedTransitiveDependencyChainFromTSModules works.', () =>
       { a: ['b', 'e'], d: ['b', 'c', 'a'], f: ['g'] },
       ['d', 'f']
     )
-  ).toEqual({"d": ["b", "c", "e", "a"], "f": ["g"]});
+  ).toEqual({ d: ['b', 'c', 'e', 'a'], f: ['g'] });
 });
 
 it('getGlobalTopologicallyOrderedTransitiveDependencyChain works.', () => {

--- a/src/__test__/dependency-graph-analyzer.test.ts
+++ b/src/__test__/dependency-graph-analyzer.test.ts
@@ -17,7 +17,7 @@ it('getTopologicallyOrderedTransitiveDependencyChainFromTSModules works.', () =>
       { a: ['b', 'e'], d: ['b', 'c', 'a'], f: ['g'] },
       ['d', 'f']
     )
-  ).toEqual(['b', 'c', 'e', 'a', 'd', 'g', 'f']);
+  ).toEqual({"d": ["b", "c", "e", "a"], "f": ["g"]});
 });
 
 it('getGlobalTopologicallyOrderedTransitiveDependencyChain works.', () => {
@@ -27,5 +27,9 @@ it('getGlobalTopologicallyOrderedTransitiveDependencyChain works.', () => {
       d: ['b', 'c', 'a'],
       f: ['g'],
     })
-  ).toEqual(['b', 'e', 'a', 'c', 'd', 'g', 'f']);
+  ).toEqual({
+    a: ['b', 'e'],
+    d: ['b', 'c', 'e', 'a'],
+    f: ['g'],
+  });
 });

--- a/src/dependency-graph-analyzer.ts
+++ b/src/dependency-graph-analyzer.ts
@@ -48,24 +48,26 @@ const getDependencyChainForTSModule = (graph: Graph, tsModule: string): readonly
 export const getTopologicallyOrderedTransitiveDependencyChainFromTSModules = (
   graph: Graph,
   tsModules: readonly string[]
-): readonly string[] => {
-  const sorted: string[] = [];
-  const set = new Set<string>();
+): Record<string, string[]> => {
+  const map: Record<string, string[]> = {};
 
   tsModules.forEach((tsModule) => {
     const oneDependencyChainSorted = getDependencyChainForTSModule(graph, tsModule);
     oneDependencyChainSorted.forEach((moduleName) => {
-      if (!set.has(moduleName)) {
-        sorted.push(moduleName);
-        set.add(moduleName);
+      if (moduleName !== tsModule) {
+        if (map[tsModule] === undefined) {
+          map[tsModule] = [moduleName];
+        } else {
+          map[tsModule] = [...(map[tsModule] ?? []), moduleName];
+        }
       }
     });
   });
 
-  return sorted;
+  return map;
 };
 
 export const getGlobalTopologicallyOrderedTransitiveDependencyChain = (
   graph: Graph
-): readonly string[] =>
+): Record<string, string[]> =>
   getTopologicallyOrderedTransitiveDependencyChainFromTSModules(graph, Object.keys(graph));

--- a/src/main-analyzer.ts
+++ b/src/main-analyzer.ts
@@ -57,7 +57,7 @@ const getTSSAResult = (projectPaths: readonly string[], diffString: string): Tss
     ),
   }));
 
-  let allCssDependencyChain: string[] = [];
+  let allCssDependencyChain: Record<string, string[]> = {};
 
   const forwardDependencyGraph = buildDependencyGraph(typescriptProjects, relevantProjectPaths);
   const reverseDependencyGraph = buildReverseDependencyGraphFromDependencyGraph(
@@ -73,9 +73,8 @@ const getTSSAResult = (projectPaths: readonly string[], diffString: string): Tss
       [changedCssPath]
     );
 
-    allCssDependencyChain.push(...forwardDependencyChain, ...reverseDependencyChain);
+    allCssDependencyChain = {...forwardDependencyChain, ...reverseDependencyChain};
   });
-  allCssDependencyChain = Array.from(new Set(allCssDependencyChain));
 
   return {
     typescriptAnalysisResult: changedTSFileReferenceAnalysisResult,

--- a/src/main-analyzer.ts
+++ b/src/main-analyzer.ts
@@ -73,7 +73,7 @@ const getTSSAResult = (projectPaths: readonly string[], diffString: string): Tss
       [changedCssPath]
     );
 
-    allCssDependencyChain = {...forwardDependencyChain, ...reverseDependencyChain};
+    allCssDependencyChain = { ...forwardDependencyChain, ...reverseDependencyChain };
   });
 
   return {

--- a/src/tssa-result.ts
+++ b/src/tssa-result.ts
@@ -10,10 +10,12 @@ export type TssaResult = {
 };
 
 const dependencyListToStringByFile = (list: Record<string, string[]>): string => {
-  let comment = "";
-  Object.keys(list).forEach((k) => comment += `Your changes to ${k} affect: \n ${list[k].map((it) => `> \`${it}\``).join('\n')};`)
+  let comment = '';
+  Object.keys(list).forEach((k) => {
+    comment += `Your changes to ${k} affect: \n ${list[k].map((it) => `> \`${it}\``).join('\n')};`;
+  });
   return comment;
-}
+};
 
 const dependencyListToString = (list: readonly string[]): string =>
   list.map((it) => `> \`${it}\``).join('\n');

--- a/src/tssa-result.ts
+++ b/src/tssa-result.ts
@@ -6,8 +6,14 @@ export type TssaResult = {
     readonly affectedFunctionChain: readonly SourceFileDefinedSymbol[];
   }[];
   /** A list of css affect chain. TODO: separate the result per file. */
-  readonly cssAnalysisResult: readonly string[];
+  readonly cssAnalysisResult: Record<string, string[]>;
 };
+
+const dependencyListToStringByFile = (list: Record<string, string[]>): string => {
+  let comment = "";
+  Object.keys(list).forEach((k) => comment += `Your changes to ${k} affect: \n ${list[k].map((it) => `> \`${it}\``).join('\n')};`)
+  return comment;
+}
 
 const dependencyListToString = (list: readonly string[]): string =>
   list.map((it) => `> \`${it}\``).join('\n');
@@ -29,11 +35,11 @@ ${dependencyListToString(affectedFunctionChain.map(sourceFileDefinedSymbolToStri
   );
 
   const cssAnalysisResultString =
-    cssAnalysisResult.length === 0
+    Object.keys(cssAnalysisResult).length === 0
       ? null
       : `Modules that your changes in css code may affect:
 
-${dependencyListToString(cssAnalysisResult)}`;
+${dependencyListToStringByFile(cssAnalysisResult)}`;
 
   const analysisResultStrings = [
     ...tsDependencyAnalysisResultStrings,


### PR DESCRIPTION
### Summary

Currently, TSSA outputs results in one long list of files that may be affected by one PR. Let's split these results by file so contributors can know what changes affect which files. 

We accomplish this by just having `getTopologicallyOrderedTransitiveDependencyChainFromTSModules()` return a mapping of changed modules to a list of modules that depend and can be affected by that module. Do the relevant parsing to output string. 

### Test Plan

👀 , `yarn test`